### PR TITLE
fix: support cotopics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cristiand391/oclif-carapace-spec-plugin",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cristiand391/oclif-carapace-spec-plugin",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4",

--- a/src/commands/carapace-gen.ts
+++ b/src/commands/carapace-gen.ts
@@ -83,6 +83,16 @@ https://github.com/carapace-sh/carapace-spec`
 
         const isCommand = "flags" in node
 
+//         if (node.id.startsWith('data:query')) {
+//           console.log(`node: data:query
+// summary: ${node.summary}
+// part: ${part}
+// existingCommand: ${JSON.stringify(existingCommand)}
+// isCommand: ${isCommand}
+// currentLevel: ${JSON.stringify(currentLevel)}
+// `)
+//         }
+
         let flags: YAMLMap | undefined
         
         if (isCommand) {
@@ -105,7 +115,18 @@ https://github.com/carapace-sh/carapace-spec`
           }
         }
 
-        if (!existingCommand) {
+        if (part === parts[parts.length - 1] && existingCommand && !('flags' in existingCommand)) {
+          const existingCommandIdx = currentLevel.findIndex(cmd => cmd.name === part);
+
+          existingCommand = {
+            description: node.summary,
+            name: part,
+            ...(isCommand ? {flags}: {}),
+            commands: existingCommand.commands
+          }
+
+          currentLevel[existingCommandIdx] = existingCommand
+        } else if (!existingCommand) {
           // Create a new command entry
           existingCommand = {
             description: node.summary,
@@ -134,6 +155,7 @@ https://github.com/carapace-sh/carapace-spec`
     // having the topic nodes first ensures their help text matches what's defined
     // in the plugin's pjson (descriptions in `oclif.topics`)
     for (const t of this.getTopics()) {
+      // if (!t.id.startsWith('data')) continue
       nodes.push({
         id: t.id,
         summary: t.summary
@@ -141,7 +163,9 @@ https://github.com/carapace-sh/carapace-spec`
     }
 
     for (const plugin of this.config.getPluginsList()) {
+      // if (plugin.name !== '@salesforce/plugin-data') continue
       for (const cmd of plugin.commands) {
+        // if (!cmd.id.startsWith('data:query')) continue
         if (cmd.state === 'deprecated' ||  cmd.hidden) continue
 
         const summary = this.sanitizeSummary(cmd.summary ?? cmd.description)

--- a/src/commands/carapace-gen.ts
+++ b/src/commands/carapace-gen.ts
@@ -83,16 +83,6 @@ https://github.com/carapace-sh/carapace-spec`
 
         const isCommand = "flags" in node
 
-//         if (node.id.startsWith('data:query')) {
-//           console.log(`node: data:query
-// summary: ${node.summary}
-// part: ${part}
-// existingCommand: ${JSON.stringify(existingCommand)}
-// isCommand: ${isCommand}
-// currentLevel: ${JSON.stringify(currentLevel)}
-// `)
-//         }
-
         let flags: YAMLMap | undefined
         
         if (isCommand) {
@@ -115,6 +105,13 @@ https://github.com/carapace-sh/carapace-spec`
           }
         }
 
+        // if on last part of the node and the existing node is a topic,
+        // then the current node is a cotopic (topic that's also a command).
+        //
+        // In these cases we want to modify the cotopic node to:
+        // 1. prefer the command's summary over the topic one
+        // 2. add the command's flags
+        // 3. add the topic's command
         if (part === parts[parts.length - 1] && existingCommand && !('flags' in existingCommand)) {
           const existingCommandIdx = currentLevel.findIndex(cmd => cmd.name === part);
 
@@ -163,9 +160,7 @@ https://github.com/carapace-sh/carapace-spec`
     }
 
     for (const plugin of this.config.getPluginsList()) {
-      // if (plugin.name !== '@salesforce/plugin-data') continue
       for (const cmd of plugin.commands) {
-        // if (!cmd.id.startsWith('data:query')) continue
         if (cmd.state === 'deprecated' ||  cmd.hidden) continue
 
         const summary = this.sanitizeSummary(cmd.summary ?? cmd.description)


### PR DESCRIPTION
This PR fixes the command tree builder not respecting cotopics (topics that are also commands)

`sf data query -<TAB>` now completes `data query` flags
![Screenshot from 2024-10-13 17-15-23](https://github.com/user-attachments/assets/a7dc61bd-ef1c-45d4-886b-30ccb85f31ef)

`sf data query resume -<TAB>` still works
![Screenshot from 2024-10-13 17-17-55](https://github.com/user-attachments/assets/8eb4ced5-4cd4-43d6-aff5-f2a44144a9b9)

`sf data query <TAB>` completes `resume`

