### PR TITLE
feat: support help/option flags

### DIFF
--- a/.github/workflows/onPushToMain.yml
+++ b/.github/workflows/onPushToMain.yml
@@ -23,4 +23,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create ${{ steps.changelog.outputs.tag }} --notes-file CHANGELOG.md
+          gh release create ${{ steps.changelog.outputs.tag }} --notes ${{ steps.changelog.outputs.clean_changelog }}

--- a/.github/workflows/onRelease.yml
+++ b/.github/workflows/onRelease.yml
@@ -3,7 +3,7 @@ name: publish
 on:
   workflow_dispatch:
   release:
-    types: [published]
+    types: [released]
 
 jobs:
   npm-publish:

--- a/src/commands/carapace-gen.ts
+++ b/src/commands/carapace-gen.ts
@@ -88,10 +88,17 @@ https://github.com/carapace-sh/carapace-spec`
         if (isCommand) {
           flags= new YAMLMap()
 
+          let hasHelpFlag = false;
+
           for (const flagName in node.flags) {
             const flag = node.flags[flagName]
 
             if (flag.deprecated || flag.hidden) continue
+
+            // check if `--help` is already taken by the command, carapace-spec panics on duplicated flags
+            if (!hasHelpFlag) {
+              hasHelpFlag = flagName === 'help'
+            }
 
             let flagDef = flag.char ? `-${flag.char}, --${flagName}` : `--${flagName}`
             if (flag.type === "option" && flag.multiple) {
@@ -101,6 +108,14 @@ https://github.com/carapace-sh/carapace-spec`
             flags.add({
               key: flagDef,
               value: node.flags[flagName].summary ?? node.flags[flagName].description ?? ''
+            })
+          }
+
+          // add oclif's global help flag
+          if (!hasHelpFlag) {
+            flags.add({
+              key: '--help',
+              value: 'Show help for command'
             })
           }
         }

--- a/src/commands/carapace-gen.ts
+++ b/src/commands/carapace-gen.ts
@@ -84,6 +84,13 @@ https://github.com/carapace-sh/carapace-spec`
         const isCommand = "flags" in node
 
         let flags: YAMLMap | undefined
+
+        const completion: {
+          flag: { [key: string]: string[] }
+        } = {
+          flag: {}
+        }
+        let hasFlagValueCompletion = false
         
         if (isCommand) {
           flags= new YAMLMap()
@@ -101,8 +108,16 @@ https://github.com/carapace-sh/carapace-spec`
             }
 
             let flagDef = flag.char ? `-${flag.char}, --${flagName}` : `--${flagName}`
-            if (flag.type === "option" && flag.multiple) {
-              flagDef += "*"
+
+            // See flag modifiers:
+            // https://carapace-sh.github.io/carapace-spec/carapace-spec/command/flags.html
+            if (flag.type === "option") {
+              flagDef += flag.multiple ? '*=' : '='
+
+              if (flag.options) {
+                completion.flag[flagName] = [...flag.options] 
+                hasFlagValueCompletion = true
+              }
             }
 
             flags.add({
@@ -134,6 +149,7 @@ https://github.com/carapace-sh/carapace-spec`
             description: node.summary,
             name: part,
             ...(isCommand ? {flags}: {}),
+            ...((isCommand && hasFlagValueCompletion ) ? { completion } : {}),
             commands: existingCommand.commands
           }
 
@@ -144,6 +160,7 @@ https://github.com/carapace-sh/carapace-spec`
             description: node.summary,
             name: part,
             ...(isCommand ? {flags}: {}),
+            ...((isCommand && hasFlagValueCompletion )? { completion } : {}),
             commands: []
           };
           currentLevel.push(existingCommand);

--- a/src/commands/carapace-gen.ts
+++ b/src/commands/carapace-gen.ts
@@ -91,6 +91,8 @@ https://github.com/carapace-sh/carapace-spec`
           flag: {}
         }
         let hasFlagValueCompletion = false
+
+        const exclusiveflags: string[][] = []
         
         if (isCommand) {
           flags= new YAMLMap()
@@ -101,6 +103,25 @@ https://github.com/carapace-sh/carapace-spec`
             const flag = node.flags[flagName]
 
             if (flag.deprecated || flag.hidden) continue
+
+            if (node.flags[flagName].exclusive) {
+              const exclusives = node.flags[flagName].exclusive.filter(flag => {
+                // @ts-ignore
+                return node.flags[flag] && !node.flags[flag].hidden
+              })
+
+              if (exclusives.length === 0) continue
+
+              // avoid duplicate `exclusiveflags` arrays
+              // this can happen if 2 or more flags define the same exclusions.
+              const sortedFlagExclusives = [...exclusives, flagName].sort()
+              const alreadyExists = exclusiveflags.find(exclusive => exclusive.toString() === sortedFlagExclusives.toString())
+
+              if (!alreadyExists) {
+                exclusiveflags.push(sortedFlagExclusives)
+              }
+            }
+
 
             // check if `--help` is already taken by the command, carapace-spec panics on duplicated flags
             if (!hasHelpFlag) {
@@ -150,6 +171,7 @@ https://github.com/carapace-sh/carapace-spec`
             name: part,
             ...(isCommand ? {flags}: {}),
             ...((isCommand && hasFlagValueCompletion ) ? { completion } : {}),
+            ...((isCommand && exclusiveflags.length > 0 ) ? { exclusiveflags } : {}),
             commands: existingCommand.commands
           }
 
@@ -160,6 +182,7 @@ https://github.com/carapace-sh/carapace-spec`
             description: node.summary,
             name: part,
             ...(isCommand ? {flags}: {}),
+            ...((isCommand && exclusiveflags.length > 0 ) ? { exclusiveflags } : {}),
             ...((isCommand && hasFlagValueCompletion )? { completion } : {}),
             commands: []
           };
@@ -184,7 +207,6 @@ https://github.com/carapace-sh/carapace-spec`
     // having the topic nodes first ensures their help text matches what's defined
     // in the plugin's pjson (descriptions in `oclif.topics`)
     for (const t of this.getTopics()) {
-      // if (!t.id.startsWith('data')) continue
       nodes.push({
         id: t.id,
         summary: t.summary


### PR DESCRIPTION
- **feat: support help flag**

all commands have `--help` included in their definition

- **feat: support flag value completion**

complete flag options, see:
https://oclif.io/docs/flags
> options: ['a', 'b'], 

- **feat: support exclusive flags**

`flag.exclusive` relationships are respected by carapace-spec.
