### PR TITLE
fix: skip exclusive flags if deprecated

### DIFF
--- a/src/commands/carapace-gen.ts
+++ b/src/commands/carapace-gen.ts
@@ -126,7 +126,7 @@ https://github.com/carapace-sh/carapace-spec`
             if (node.flags[flagName].exclusive) {
               const exclusives = node.flags[flagName].exclusive.filter(flag => {
                 // @ts-ignore
-                return node.flags[flag] && !node.flags[flag].hidden
+                return node.flags[flag] && !node.flags[flag].hidden && !node.flags[flag].deprecated
               })
 
               if (exclusives.length === 0) continue


### PR DESCRIPTION
Fixes: https://github.com/cristiand391/oclif-carapace-spec-plugin/issues/7

tested with `@salesforce/cli/2.85.7` which includes the `plugin-data` changes mentioned above in #7.
First tested with sf v 2.86.8 but `carapace-spec` panicked due to a flag name collision in the RC.