### PR TITLE
feat: bump/remove deps + drop node v18 + add UTs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: unit tests
+
+on:
+  push:
+    branches-ignore: [main]
+  workflow_dispatch:
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup node
+      # https://github.com/actions/setup-node/releases/tag/v3.8.1
+        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d
+        with:
+          node-version: lts/*
+          registry-url: 'https://registry.npmjs.org'
+          cache: npm
+      - name: Install dependencies
+        run: npm install
+      - name: Run unit tests
+        run: npm run test

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ https://carapace-sh.github.io/carapace-spec/carapace-spec/usage.html
 * Completion overrides (see `Macros` section below)
 
 ## Requirements
- * `carapace-spec`: [dowload the binary for your OS]([url](https://github.com/carapace-sh/carapace-spec/releases)) and put it in your `PATH`
+ * `carapace-spec`: [dowload the binary for your OS](https://github.com/carapace-sh/carapace-spec/releases) and put it in your `PATH`
  * oclif CLI that supports installing plugins via `plugins install`
 
 ## Install
 
 ```bash
-plugins install @cristiand391/oclif-carapace-spec-plugin
+<CLI> plugins install @cristiand391/oclif-carapace-spec-plugin
 ```
 
 Then run the `carapace-gen` command and follow the instructions to source the spec in your shell.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ https://carapace-sh.github.io/carapace-spec/carapace-spec/usage.html
 
 ## Requirements
  * `carapace-spec`: [dowload the binary for your OS](https://github.com/carapace-sh/carapace-spec/releases) and put it in your `PATH`
- * oclif CLI that supports installing plugins via `plugins install`
+ * oclif CLI that supports installing plugins via [`plugins install`]([https://github.com/oclif/plugin-plugins](https://github.com/oclif/plugin-plugins?tab=readme-ov-file#what-is-this))
 
 ## Install
 
@@ -66,17 +66,11 @@ It uses the `exec` macro for `--target-org` and `--target-dev-hub` flags to get 
 ### Usage
 
 1. Define a YAML file with completion definitions like in the example above.
-2. Set the `<BIN>_CARAPACE_SPEC_MACROS_FILE` env var to the path to the YAML file.
-3. Run `sf carapace-gen --refresh-cache`.
+2. Set the `<CLI>_CARAPACE_SPEC_MACROS_FILE` env var to the path to the YAML file.
+3. Run `<CLI> carapace-gen --refresh-cache`.
    
 > [!NOTE]  
-The `<BIN>` part in the env var in step 2 refers to the name of your oclif CLI. For instance, for the Salesforce CLI (`sf`) the env var should be `SF_CARAPACE_SPEC_MACROS_FILE`.
+The `<CLI>` part in the env var in step 2 refers to the executable name of your oclif CLI. For instance, for the Salesforce CLI (`sf`) the env var should be `SF_CARAPACE_SPEC_MACROS_FILE`.
 
 > [!NOTE]  
-This plugin re-generates the carapace spec everytime you install/uninstall plugins via `plugins install/uninstall`, make sure to set the `<BIN>_CARAPACE_SPEC_MACROS_FILE` env var in your shell RC file so that you don't miss the custom completions when the automatic re-generation happens under the hood.
-
-
-## Why should I use this instead of `@oclif/plugin-autocomplete`?
-`@oclif/plugin-autocomplete` only supports bash, zsh and powershell while `carapace-spec` supports those + 6 additional shells: https://carapace-sh.github.io/carapace-spec/carapace-spec/usage.html
-
-Except for flag exclusive relationships and completion overrides (macros), the completion experience is pretty much the same so if `oclif/plugin-autocomplete` works for you then you can ignore this.
+This plugin re-generates the carapace spec everytime you install/uninstall plugins via `plugins install/uninstall`, make sure to set the `<CLI>_CARAPACE_SPEC_MACROS_FILE` env var in your shell RC file so that you don't miss the custom completions when the automatic re-generation happens under the hood.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cristiand391/oclif-carapace-spec-plugin",
-  "version": "0.1.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cristiand391/oclif-carapace-spec-plugin",
-      "version": "0.1.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4",
@@ -2776,10 +2776,11 @@
       "dev": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@oclif/core": "^4",
         "ejs": "^3.1.10",
-        "yaml": "^2.5.1"
+        "yaml": "^2.8.0"
       },
       "devDependencies": {
         "@types/ejs": "^3.1.5",
@@ -24,7 +24,7 @@
         "typescript": "^5"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=20"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -4883,14 +4883,15 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
-      "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+      "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
       }
     },
     "node_modules/yn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,12 @@
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4",
-        "ansis": "^3.3.2",
         "ejs": "^3.1.10",
         "yaml": "^2.5.1"
       },
       "devDependencies": {
         "@types/ejs": "^3.1.5",
-        "@types/node": "^18",
+        "@types/node": "^22",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
         "eslint": "^8",
@@ -25,7 +24,7 @@
         "typescript": "^5"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -1178,21 +1177,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@inquirer/core/node_modules/@types/node": {
-      "version": "22.6.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.6.1.tgz",
-      "integrity": "sha512-V48tCfcKb/e6cVUigLAaJDAILdMP0fUW6BidkPK4GpGjXcfbnoHasCZDwz3N3yVt5we2RHm4XTQCpv0KJz9zqw==",
-      "dev": true,
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
-    "node_modules/@inquirer/core/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true
-    },
     "node_modules/@inquirer/core/node_modules/wrap-ansi": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -2193,12 +2177,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.19.50",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.50.tgz",
-      "integrity": "sha512-xonK+NRrMBRtkL1hVCc3G+uXtjh1Al4opBLjqVmipe5ZAaBYWW6cNAiBVZ1BvmkBhep698rP3UM3aRAdSALuhg==",
+      "version": "22.15.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.21.tgz",
+      "integrity": "sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/semver": {
@@ -4770,10 +4755,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/universalify": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
   "homepage": "https://github.com/cristiand391/oclif-carapace-spec-plugin",
   "bugs": "https://github.com/cristiand391/oclif-carapace-spec-plugin/issues",
   "engines": {
-    "node": ">=22"
+    "node": ">=20"
   },
   "dependencies": {
     "@oclif/core": "^4",
     "ejs": "^3.1.10",
-    "yaml": "^2.5.1"
+    "yaml": "^2.8.0"
   },
   "devDependencies": {
     "@types/ejs": "^3.1.5",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "build": "rm -rf dist && tsc -b",
     "lint": "eslint . --ext .ts",
     "postpack": "rm -f oclif.manifest.json",
-    "prepack": "oclif manifest"
+    "prepack": "oclif manifest",
+    "test": "node --loader ts-node/esm --test test/**/*.test.ts"
   },
   "types": "dist/index.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -9,17 +9,16 @@
   "homepage": "https://github.com/cristiand391/oclif-carapace-spec-plugin",
   "bugs": "https://github.com/cristiand391/oclif-carapace-spec-plugin/issues",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22"
   },
   "dependencies": {
     "@oclif/core": "^4",
-    "ansis": "^3.3.2",
     "ejs": "^3.1.10",
     "yaml": "^2.5.1"
   },
   "devDependencies": {
     "@types/ejs": "^3.1.5",
-    "@types/node": "^18",
+    "@types/node": "^22",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
     "eslint": "^8",

--- a/src/commands/carapace-gen.ts
+++ b/src/commands/carapace-gen.ts
@@ -3,6 +3,7 @@ import {bold,cyan} from 'ansis'
 import * as ejs from 'ejs'
 import {mkdir,writeFile,readFile} from 'node:fs/promises'
 import YAML, { YAMLMap } from 'yaml'
+import {buildCommandTree} from '../utils/buildCommandTree.js'
 
 type YamlCommandNode = {
   name: string;
@@ -62,7 +63,7 @@ https://github.com/carapace-sh/carapace-spec`
     const macrosFilepath = this.config.scopedEnvVar('CARAPACE_SPEC_MACROS_FILE')
     const macros = macrosFilepath ? YAML.parse(await readFile(macrosFilepath, 'utf8')) : undefined
 
-    await writeFile(specPath, YAML.stringify(this.buildCommandTree(commandNodes, macros), {
+    await writeFile(specPath, YAML.stringify(buildCommandTree(commandNodes, macros, bin, this.config.pjson.description ?? `${bin} CLI`), {
       // avoid using YAML anchors in completion file, carapace doesn't like them.
       aliasDuplicateObjects: false
     }))
@@ -84,152 +85,6 @@ https://github.com/carapace-sh/carapace-spec`
     }
   }
   
-  private buildCommandTree(nodes: Node[], macros: Macros | undefined) {
-    const commandTree: {
-      name: string,
-      description: string;
-      commands: YamlCommandNode[]
-    } = { name: this.config.bin, description: this.config.pjson.description ?? `${this.config.bin} CLI`,commands: []  };
-
-    for (const node of nodes) {
-      const parts = node.id.split(':')
-      let currentLevel = commandTree.commands;
-
-      // Traverse or create the command hierarchy
-      for (const part of parts) {
-        // Check if the command already exists at this level
-        let existingCommand = currentLevel.find(cmd => cmd.name === part);
-
-        const isCommand = "flags" in node
-
-        let flags: YAMLMap | undefined
-
-        const completion: {
-          flag: { [key: string]: string[] }
-        } = {
-          flag: {}
-        }
-        let hasFlagValueCompletion = false
-
-        const exclusiveflags: string[][] = []
-        
-        if (isCommand) {
-          flags= new YAMLMap()
-
-          let hasHelpFlag = false;
-
-          for (const flagName in node.flags) {
-            const flag = node.flags[flagName]
-
-            if (flag.deprecated || flag.hidden) continue
-
-            if (node.flags[flagName].exclusive) {
-              const exclusives = node.flags[flagName].exclusive.filter(flag => {
-                // @ts-ignore
-                return node.flags[flag] && !node.flags[flag].hidden && !node.flags[flag].deprecated
-              })
-
-              if (exclusives.length === 0) continue
-
-              // avoid duplicate `exclusiveflags` arrays
-              // this can happen if 2 or more flags define the same exclusions.
-              const sortedFlagExclusives = [...exclusives, flagName].sort()
-              const alreadyExists = exclusiveflags.find(exclusive => exclusive.toString() === sortedFlagExclusives.toString())
-
-              if (!alreadyExists) {
-                exclusiveflags.push(sortedFlagExclusives)
-              }
-            }
-
-
-            // check if `--help` is already taken by the command, carapace-spec panics on duplicated flags
-            if (!hasHelpFlag) {
-              hasHelpFlag = flagName === 'help'
-            }
-
-            let flagDef = flag.char ? `-${flag.char}, --${flagName}` : `--${flagName}`
-
-            // See flag modifiers:
-            // https://carapace-sh.github.io/carapace-spec/carapace-spec/command/flags.html
-            if (flag.type === "option") {
-              flagDef += flag.multiple ? '*=' : '='
-
-              if (flag.options) {
-                completion.flag[flagName] = [...flag.options] 
-                hasFlagValueCompletion = true
-              }
-            }
-
-            flags.add({
-              key: flagDef,
-              value: node.flags[flagName].summary ?? node.flags[flagName].description ?? ''
-            })
-
-            if (macros) {
-              if (macros.persistentFlagsCompletion && Object.hasOwn(macros.persistentFlagsCompletion, flagName)) {
-                completion.flag[flagName] = macros.persistentFlagsCompletion[flagName]
-                hasFlagValueCompletion = true
-              }
-              if (macros.commandOverrides?.flags && Object.hasOwn(macros.commandOverrides.flags, node.id)) {
-                if (Object.hasOwn(macros.commandOverrides.flags[node.id], flagName)) {
-                  completion.flag[flagName] = macros.commandOverrides.flags[node.id][flagName]
-                  hasFlagValueCompletion = true
-                }
-              }
-            }
-            
-          }
-
-          // add oclif's global help flag
-          if (!hasHelpFlag) {
-            flags.add({
-              key: '--help',
-              value: 'Show help for command'
-            })
-          }
-        }
-
-        // if on last part of the node and the existing node is a topic,
-        // then the current node is a cotopic (topic that's also a command).
-        //
-        // In these cases we want to modify the cotopic node to:
-        // 1. prefer the command's summary over the topic one
-        // 2. add the command's flags
-        // 3. add the topic's command
-        if (part === parts[parts.length - 1] && existingCommand && !('flags' in existingCommand)) {
-          const existingCommandIdx = currentLevel.findIndex(cmd => cmd.name === part);
-
-          existingCommand = {
-            description: node.summary,
-            name: part,
-            ...(isCommand ? {flags}: {}),
-            ...((isCommand && hasFlagValueCompletion ) ? { completion } : {}),
-            ...((isCommand && exclusiveflags.length > 0 ) ? { exclusiveflags } : {}),
-            commands: existingCommand.commands
-          }
-
-          currentLevel[existingCommandIdx] = existingCommand
-        } else if (!existingCommand) {
-          // Create a new command entry
-          existingCommand = {
-            description: node.summary,
-            name: part,
-            ...(isCommand ? {flags}: {}),
-            ...((isCommand && exclusiveflags.length > 0 ) ? { exclusiveflags } : {}),
-            ...((isCommand && hasFlagValueCompletion )? { completion } : {}),
-            commands: []
-          };
-          currentLevel.push(existingCommand);
-        }
-
-        // Move down to the next level of commands
-        currentLevel = existingCommand.commands;
-      }
-    }
-
-    return commandTree;
-  }
-
   private getCommandNodes(): Node[] {
     const nodes: Node[] = []
 

--- a/src/commands/carapace-gen.ts
+++ b/src/commands/carapace-gen.ts
@@ -1,15 +1,9 @@
 import {Command, Flags, Interfaces} from '@oclif/core'
-import {bold,cyan} from 'ansis'
 import * as ejs from 'ejs'
 import {mkdir,writeFile,readFile} from 'node:fs/promises'
-import YAML, { YAMLMap } from 'yaml'
+import {styleText} from 'node:util'
+import YAML from 'yaml'
 import {buildCommandTree} from '../utils/buildCommandTree.js'
-
-type YamlCommandNode = {
-  name: string;
-  description: string;
-  commands: YamlCommandNode[]
-}
 
 type CommandNode = {
   flags?: {[name: string]: Command.Flag.Cached}
@@ -23,19 +17,6 @@ type TopicNode = {
 }
 
 type Node = CommandNode | TopicNode
-
-type Macros = {
-  persistentFlagsCompletion?: {
-    [name: string]: string[];
-  };
-  commandOverrides?: {
-    flags?: {
-      [name: string]: {
-        [name: string]: string[];
-      };
-    };
-  };
-};
 
 export default class CarapaceGen extends Command {
   static override description = `Generate a carapace spec file
@@ -72,15 +53,15 @@ https://github.com/carapace-sh/carapace-spec`
       this.log(`
 1) Source the following spec file in your shell profile:
 
-  ${cyan(specPath)}
+  ${styleText('cyan',specPath)}
 
-  ${bold('Instructions for supported shells by carapace-gen:')}
+  ${styleText('bold','Instructions for supported shells by carapace-gen:')}
   https://carapace-sh.github.io/carapace-spec/carapace-spec/usage.html
 
 2) Start using autocomplete
 
-  ${cyan(`${bin} <TAB>`)}              ## Command completion
-  ${cyan(`${bin} command --<TAB>`)}    ## Flag completion
+  ${styleText('cyan',`${bin} <TAB>`)}              ## Command completion
+  ${styleText('cyan',`${bin} command --<TAB>`)}    ## Flag completion
 `)
     }
   }

--- a/src/utils/buildCommandTree.ts
+++ b/src/utils/buildCommandTree.ts
@@ -38,7 +38,7 @@ type Macros = {
   };
 };
 
-export type CommandTree = {
+type CommandTree = {
   name: string;
   description: string;
   commands: YamlCommandNode[];

--- a/src/utils/buildCommandTree.ts
+++ b/src/utils/buildCommandTree.ts
@@ -1,0 +1,189 @@
+import {Command} from '@oclif/core'
+import {YAMLMap} from 'yaml'
+
+type YamlCommandNode = {
+  name: string;
+  description: string;
+  commands: YamlCommandNode[];
+  flags?: YAMLMap;
+  completion?: {
+    flag: { [key: string]: string[] }
+  };
+  exclusiveflags?: string[][];
+}
+
+type CommandNode = {
+  flags?: {[name: string]: Command.Flag.Cached}
+  id: string
+  summary: string
+}
+
+type TopicNode = {
+  id: string
+  summary: string
+}
+
+type Node = CommandNode | TopicNode
+
+type Macros = {
+  persistentFlagsCompletion?: {
+    [name: string]: string[];
+  };
+  commandOverrides?: {
+    flags?: {
+      [name: string]: {
+        [name: string]: string[];
+      };
+    };
+  };
+};
+
+export type CommandTree = {
+  name: string;
+  description: string;
+  commands: YamlCommandNode[];
+}
+
+export function buildCommandTree(nodes: Node[], macros: Macros | undefined, bin: string, description: string): CommandTree {
+  const commandTree: CommandTree = { 
+    name: bin, 
+    description: description, 
+    commands: [] 
+  };
+
+  for (const node of nodes) {
+    const parts = node.id.split(':')
+    let currentLevel = commandTree.commands;
+
+    // Traverse or create the command hierarchy
+    for (const part of parts) {
+      // Check if the command already exists at this level
+      let existingCommand = currentLevel.find(cmd => cmd.name === part);
+
+      const isCommand = "flags" in node
+
+      let flags: YAMLMap | undefined
+
+      const completion: {
+        flag: { [key: string]: string[] }
+      } = {
+        flag: {}
+      }
+      let hasFlagValueCompletion = false
+
+      const exclusiveflags: string[][] = []
+      
+      if (isCommand) {
+        flags = new YAMLMap()
+
+        let hasHelpFlag = false;
+
+        for (const flagName in node.flags) {
+          const flag = node.flags[flagName]
+
+          if (flag.deprecated || flag.hidden) continue
+
+          if (node.flags[flagName].exclusive) {
+            const exclusives = node.flags[flagName].exclusive.filter(flag => {
+              // @ts-ignore
+              return node.flags[flag] && !node.flags[flag].hidden && !node.flags[flag].deprecated
+            })
+
+            if (exclusives.length === 0) continue
+
+            // avoid duplicate `exclusiveflags` arrays
+            // this can happen if 2 or more flags define the same exclusions.
+            const sortedFlagExclusives = [...exclusives, flagName].sort()
+            const alreadyExists = exclusiveflags.find(exclusive => exclusive.toString() === sortedFlagExclusives.toString())
+
+            if (!alreadyExists) {
+              exclusiveflags.push(sortedFlagExclusives)
+            }
+          }
+
+          // check if `--help` is already taken by the command, carapace-spec panics on duplicated flags
+          if (!hasHelpFlag) {
+            hasHelpFlag = flagName === 'help'
+          }
+
+          let flagDef = flag.char ? `-${flag.char}, --${flagName}` : `--${flagName}`
+
+          // See flag modifiers:
+          // https://carapace-sh.github.io/carapace-spec/carapace-spec/command/flags.html
+          if (flag.type === "option") {
+            flagDef += flag.multiple ? '*=' : '='
+
+            if (flag.options) {
+              completion.flag[flagName] = [...flag.options] 
+              hasFlagValueCompletion = true
+            }
+          }
+
+          flags.add({
+            key: flagDef,
+            value: node.flags[flagName].summary ?? node.flags[flagName].description ?? ''
+          })
+
+          if (macros) {
+            if (macros.persistentFlagsCompletion && Object.hasOwn(macros.persistentFlagsCompletion, flagName)) {
+              completion.flag[flagName] = macros.persistentFlagsCompletion[flagName]
+              hasFlagValueCompletion = true
+            }
+            if (macros.commandOverrides?.flags && Object.hasOwn(macros.commandOverrides.flags, node.id)) {
+              if (Object.hasOwn(macros.commandOverrides.flags[node.id], flagName)) {
+                completion.flag[flagName] = macros.commandOverrides.flags[node.id][flagName]
+                hasFlagValueCompletion = true
+              }
+            }
+          }
+        }
+
+        // add oclif's global help flag
+        if (!hasHelpFlag) {
+          flags.add({
+            key: '--help',
+            value: 'Show help for command'
+          })
+        }
+      }
+
+      // if on last part of the node and the existing node is a topic,
+      // then the current node is a cotopic (topic that's also a command).
+      //
+      // In these cases we want to modify the cotopic node to:
+      // 1. prefer the command's summary over the topic one
+      // 2. add the command's flags
+      // 3. add the topic's command
+      if (part === parts[parts.length - 1] && existingCommand && !('flags' in existingCommand)) {
+        const existingCommandIdx = currentLevel.findIndex(cmd => cmd.name === part);
+
+        existingCommand = {
+          description: node.summary,
+          name: part,
+          ...(isCommand ? {flags}: {}),
+          ...((isCommand && hasFlagValueCompletion ) ? { completion } : {}),
+          ...((isCommand && exclusiveflags.length > 0 ) ? { exclusiveflags } : {}),
+          commands: existingCommand.commands
+        }
+
+        currentLevel[existingCommandIdx] = existingCommand
+      } else if (!existingCommand) {
+        // Create a new command entry
+        existingCommand = {
+          description: node.summary,
+          name: part,
+          ...(isCommand ? {flags}: {}),
+          ...((isCommand && exclusiveflags.length > 0 ) ? { exclusiveflags } : {}),
+          ...((isCommand && hasFlagValueCompletion )? { completion } : {}),
+          commands: []
+        };
+        currentLevel.push(existingCommand);
+      }
+
+      // Move down to the next level of commands
+      currentLevel = existingCommand.commands;
+    }
+  }
+
+  return commandTree;
+} 

--- a/test/buildCommandTree.test.ts
+++ b/test/buildCommandTree.test.ts
@@ -1,0 +1,231 @@
+import {test} from 'node:test'
+import {buildCommandTree} from '../src/utils/buildCommandTree.js'
+import {YAMLMap} from 'yaml'
+import assert from 'node:assert'
+
+test('buildCommandTree', async (t) => {
+  await t.test('should create a basic command tree', () => {
+    const nodes = [{
+      id: 'test',
+      summary: 'Test command',
+      flags: {
+        help: {
+          type: 'boolean',
+          char: 'h',
+          description: 'Show help for command',
+          hidden: false,
+          required: false,
+          default: false,
+          exclusive: [],
+        }
+      }
+    }]
+
+    const result = buildCommandTree(nodes, undefined, 'test-cli', 'Test CLI')
+    
+    assert.strictEqual(result.name, 'test-cli')
+    assert.strictEqual(result.description, 'Test CLI')
+    assert.strictEqual(result.commands.length, 1)
+    assert.strictEqual(result.commands[0].name, 'test')
+    assert.strictEqual(result.commands[0].description, 'Test command')
+    assert(result.commands[0].flags instanceof YAMLMap)
+  })
+
+  await t.test('should handle nested commands', () => {
+    const nodes = [
+      {
+        id: 'parent',
+        summary: 'Parent command',
+        flags: {}
+      },
+      {
+        id: 'parent:child',
+        summary: 'Child command',
+        flags: {}
+      }
+    ]
+
+    const result = buildCommandTree(nodes, undefined, 'test-cli', 'Test CLI')
+    
+    assert.strictEqual(result.commands.length, 1)
+    assert.strictEqual(result.commands[0].name, 'parent')
+    assert.strictEqual(result.commands[0].commands.length, 1)
+    assert.strictEqual(result.commands[0].commands[0].name, 'child')
+  })
+
+  await t.test('should handle flag relationships', () => {
+    const nodes = [{
+      id: 'test',
+      summary: 'Test command',
+      flags: {
+        flag1: {
+          type: 'boolean',
+          description: 'Flag 1',
+          exclusive: ['flag2'],
+        },
+        flag2: {
+          type: 'boolean',
+          description: 'Flag 2',
+          exclusive: ['flag1'],
+        }
+      }
+    }]
+
+    const result = buildCommandTree(nodes, undefined, 'test-cli', 'Test CLI')
+    
+    assert.deepStrictEqual(result.commands[0].exclusiveflags, [['flag1', 'flag2']])
+  })
+
+  await t.test('should handle flag modifiers', () => {
+    const nodes = [{
+      id: 'test',
+      summary: 'Test command',
+      flags: {
+        stringFlag: {
+          type: 'option',
+          description: 'String flag',
+          multiple: true,
+        },
+        boolFlag: {
+          type: 'boolean',
+          description: 'Boolean flag',
+        }
+      }
+    }]
+
+    const result = buildCommandTree(nodes, undefined, 'test-cli', 'Test CLI')
+    const flags = result.commands[0].flags as YAMLMap
+    
+    assert.strictEqual(flags.get('--stringFlag*='), 'String flag')
+    assert.strictEqual(flags.get('--boolFlag'), 'Boolean flag')
+  })
+
+  await t.test('should handle flag completion', () => {
+    const nodes = [{
+      id: 'test',
+      summary: 'Test command',
+      flags: {
+        enumFlag: {
+          type: 'option',
+          description: 'Enum flag',
+          options: ['option1', 'option2', 'option3'],
+        }
+      }
+    }]
+
+    const result = buildCommandTree(nodes, undefined, 'test-cli', 'Test CLI')
+    
+    assert.deepStrictEqual(result.commands[0].completion?.flag.enumFlag, ['option1', 'option2', 'option3'])
+  })
+
+  await t.test('should handle macros for flag completion', () => {
+    const nodes = [{
+      id: 'test',
+      summary: 'Test command',
+      flags: {
+        customFlag: {
+          type: 'option',
+          description: 'Custom flag',
+        }
+      }
+    }]
+
+    const macros = {
+      persistentFlagsCompletion: {
+        customFlag: ['value1', 'value2']
+      }
+    }
+
+    const result = buildCommandTree(nodes, macros, 'test-cli', 'Test CLI')
+    
+    assert.deepStrictEqual(result.commands[0].completion?.flag.customFlag, ['value1', 'value2'])
+  })
+
+  await t.test('should handle command overrides in macros', () => {
+    const nodes = [{
+      id: 'test',
+      summary: 'Test command',
+      flags: {
+        customFlag: {
+          type: 'option',
+          description: 'Custom flag',
+        }
+      }
+    }]
+
+    const macros = {
+      commandOverrides: {
+        flags: {
+          'test': {
+            customFlag: ['override1', 'override2']
+          }
+        }
+      }
+    }
+
+    const result = buildCommandTree(nodes, macros, 'test-cli', 'Test CLI')
+    
+    assert.deepStrictEqual(result.commands[0].completion?.flag.customFlag, ['override1', 'override2'])
+  })
+
+  await t.test('should handle deprecated and hidden flags', () => {
+    const nodes = [{
+      id: 'test',
+      summary: 'Test command',
+      flags: {
+        deprecatedFlag: {
+          type: 'boolean',
+          description: 'Deprecated flag',
+          deprecated: true,
+        },
+        hiddenFlag: {
+          type: 'boolean',
+          description: 'Hidden flag',
+          hidden: true,
+        },
+        visibleFlag: {
+          type: 'boolean',
+          description: 'Visible flag',
+        }
+      }
+    }]
+
+    const result = buildCommandTree(nodes, undefined, 'test-cli', 'Test CLI')
+    const flags = result.commands[0].flags as YAMLMap
+    
+    assert.strictEqual(flags.get('--deprecatedFlag'), undefined)
+    assert.strictEqual(flags.get('--hiddenFlag'), undefined)
+    assert.strictEqual(flags.get('--visibleFlag'), 'Visible flag')
+  })
+
+  await t.test('should handle help flag correctly', () => {
+    const nodes = [{
+      id: 'test',
+      summary: 'Test command',
+      flags: {
+        help: {
+          type: 'boolean',
+          description: 'Custom help flag',
+        }
+      }
+    }]
+
+    const result = buildCommandTree(nodes, undefined, 'test-cli', 'Test CLI')
+    const flags = result.commands[0].flags as YAMLMap
+    
+    assert.strictEqual(flags.get('--help'), 'Custom help flag')
+  })
+
+  await t.test('should add help flag if not present', () => {
+    const nodes = [{
+      id: 'test',
+      summary: 'Test command',
+      flags: {}
+    }]
+
+    const result = buildCommandTree(nodes, undefined, 'test-cli', 'Test CLI')
+    const flags = result.commands[0].flags as YAMLMap
+    
+    assert.strictEqual(flags.get('--help'), 'Show help for command')
+  })
+}) 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "module": "Node16",
+    "module": "nodenext",
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,
-    "target": "es2022",
+    "target": "ES2023",
     "moduleResolution": "node16"
   },
   "include": ["./src/**/*"],


### PR DESCRIPTION
* Added some UTs to cover the "build command tree" helper
* Updated readme 
* drop support for node v18
* bump `yaml` dep to latest
* drop `ansis` in favor of node's native utils 