### PR TITLE
feat: supporting carapace (not carapace-spec) by generating spec file in carapace spec dir (`${UserConfigDir}/carapace/specs/${bin}.yaml`)

### DIFF
--- a/src/commands/carapace-gen.ts
+++ b/src/commands/carapace-gen.ts
@@ -1,9 +1,11 @@
 import {Command, Flags, Interfaces} from '@oclif/core'
 import * as ejs from 'ejs'
 import {mkdir,writeFile,readFile} from 'node:fs/promises'
+import {join} from 'node:path'
 import {styleText} from 'node:util'
 import YAML from 'yaml'
 import {buildCommandTree} from '../utils/buildCommandTree.js'
+import { getUserConfigDir } from '../utils/getUserConfigDir.js'
 
 type CommandNode = {
   flags?: {[name: string]: Command.Flag.Cached}
@@ -31,11 +33,13 @@ https://github.com/carapace-sh/carapace-spec`
   public async run(): Promise<void> {
     const { flags } = await this.parse(CarapaceGen)
 
-    const { bin, cacheDir } = this.config
+    const userConfigDir = getUserConfigDir();
+    const { bin } = this.config
 
-    const specPath = `${cacheDir}/oclif-carapace-spec/${bin}.yml`
+    const specDir = join(userConfigDir, "carapace", "specs");
+    const specPath = join(specDir, `${bin}.yaml`);
 
-    await mkdir(`${cacheDir}/oclif-carapace-spec`, {
+    await mkdir(specDir, {
       recursive: true
     })
 

--- a/src/utils/getUserConfigDir.ts
+++ b/src/utils/getUserConfigDir.ts
@@ -1,0 +1,39 @@
+import {homedir} from "node:os";
+import {join} from "node:path";
+
+/**
+ * getUserConfigDir returns the default directory to use for user-specific
+ * configuration data, following the same rules as Go's os.UserConfigDir.
+ *
+ * Throws an Error if the directory cannot be determined.
+ */
+export function getUserConfigDir(): string {
+  const platform = process.platform;
+
+  // Windows
+  if (platform === "win32") {
+    const appData = process.env.APPDATA;
+    if (appData) {
+      return appData;
+    }
+    throw new Error("APPDATA is not set");
+  }
+
+  const home = homedir();
+  if (!home) {
+    throw new Error("Home directory not found");
+  }
+
+  // macOS
+  if (platform === "darwin") {
+    return join(home, "Library", "Application Support");
+  }
+
+  // Unix/Linux
+  const xdgConfigHome = process.env.XDG_CONFIG_HOME;
+  if (xdgConfigHome) {
+    return xdgConfigHome;
+  }
+
+  return join(home, ".config");
+}


### PR DESCRIPTION
resolves https://github.com/cristiand391/oclif-carapace-spec-plugin/issues/11