### PR TITLE
fix: respect `XDG_CONFIG_HOME` in all OSes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ oclif-carapace-spec-plugin
 
 An oclif plugin to generate a carapace spec!
 
-`carapace-spec` allows to define CLI completions in a spec file, you can use it to get shell completion in all supported shells listed here:
+`carapace` allows to define CLI completions in a spec file, you can use it to get shell completion in all supported shells listed here:
 https://carapace-sh.github.io/carapace-spec/carapace-spec/usage.html
 
 
@@ -19,7 +19,7 @@ https://carapace-sh.github.io/carapace-spec/carapace-spec/usage.html
 * Completion overrides (see `Macros` section below)
 
 ## Requirements
- * `carapace-spec`: [dowload the binary for your OS](https://github.com/carapace-sh/carapace-spec/releases) and put it in your `PATH`
+ * `carapace-spec` or `carapace-bin`: [carapace-spec: dowload the binary for your OS](https://github.com/carapace-sh/carapace-spec/releases) and put it in your `PATH`. [carapace: see install instructions](https://carapace-sh.github.io/carapace-bin/install.html)
  * oclif CLI that supports installing plugins via [`plugins install`]([https://github.com/oclif/plugin-plugins](https://github.com/oclif/plugin-plugins?tab=readme-ov-file#what-is-this))
 
 ## Install
@@ -31,7 +31,7 @@ https://carapace-sh.github.io/carapace-spec/carapace-spec/usage.html
 Then run the `carapace-gen` command and follow the instructions to source the spec in your shell.
 
 ## Macros
-`carapace-spec` allows to use macros for customizing completion style and values:
+`carapace` allows to use macros for customizing completion style and values:
 
 https://carapace-sh.github.io/carapace-spec/carapace-spec/macros.html
 

--- a/src/commands/carapace-gen.ts
+++ b/src/commands/carapace-gen.ts
@@ -23,9 +23,12 @@ type Node = CommandNode | TopicNode
 export default class CarapaceGen extends Command {
   static override description = `Generate a carapace spec file
 
-Use \`carapace-gen\` to get shell completion:
-https://github.com/carapace-sh/carapace-spec`
+Use this command to generate a carapace spec for your CLI:
+https://carapace-sh.github.io/carapace-bin/spec.html
 
+Spec format:
+https://carapace-sh.github.io/carapace-spec/
+`
   static flags = {
     'refresh-cache': Flags.boolean({char: 'r', summary: 'Refresh cache (ignores displaying instructions)'}),
   }
@@ -55,17 +58,17 @@ https://github.com/carapace-sh/carapace-spec`
 
     if (!flags['refresh-cache']) {
       this.log(`
-1) Source the following spec file in your shell profile:
+Spec written to:
 
   ${styleText('cyan',specPath)}
 
-  ${styleText('bold','Instructions for supported shells by carapace-gen:')}
-  https://carapace-sh.github.io/carapace-spec/carapace-spec/usage.html
+If using \`carapace\` (carapace-bin), the spec will be loaded automatically.
+${styleText('bold','Setup instructions:')}
+https://carapace-sh.github.io/carapace-bin/setup.html
 
-2) Start using autocomplete
-
-  ${styleText('cyan',`${bin} <TAB>`)}              ## Command completion
-  ${styleText('cyan',`${bin} command --<TAB>`)}    ## Flag completion
+If using \`carapace-spec\`, source the spec file in your shell profile
+${styleText('bold','Setup instructions:')}
+https://carapace-sh.github.io/carapace-spec/carapace-spec/usage.html
 `)
     }
   }

--- a/src/utils/getUserConfigDir.ts
+++ b/src/utils/getUserConfigDir.ts
@@ -3,11 +3,16 @@ import {join} from "node:path";
 
 /**
  * getUserConfigDir returns the default directory to use for user-specific
- * configuration data, following the same rules as Go's os.UserConfigDir.
- *
- * Throws an Error if the directory cannot be determined.
+ * configuration data.
  */
 export function getUserConfigDir(): string {
+  // carapace respects `XDG_CONFIG_HOME` on all OSes:
+  // https://carapace-sh.github.io/carapace-bin/setup/userConfigDir.html
+  const xdgConfigHome = process.env.XDG_CONFIG_HOME;
+  if (xdgConfigHome) {
+    return xdgConfigHome;
+  }
+
   const platform = process.platform;
 
   // Windows
@@ -27,12 +32,6 @@ export function getUserConfigDir(): string {
   // macOS
   if (platform === "darwin") {
     return join(home, "Library", "Application Support");
-  }
-
-  // Unix/Linux
-  const xdgConfigHome = process.env.XDG_CONFIG_HOME;
-  if (xdgConfigHome) {
-    return xdgConfigHome;
   }
 
   return join(home, ".config");


### PR DESCRIPTION
follow up of https://github.com/cristiand391/oclif-carapace-spec-plugin/pull/12

The current changes in `main` don't work in macos when using `carapace` and have `XDG_CONFIG_HOME` env var set.

`carapace` does respect the env var in all OSes but the current code only looked for it on linux:
https://carapace-sh.github.io/carapace-bin/setup/userConfigDir.html

TODO:

- [x] update printed msg and README for `carapace` instructions
- [x] remove refs to `carapace-spec`?